### PR TITLE
--disable-tls-checks allows the usage of TLS1.0+ instead of the OS default

### DIFF
--- a/lib/cms_scanner/browser.rb
+++ b/lib/cms_scanner/browser.rb
@@ -57,6 +57,8 @@ module CMSScanner
         # See http://curl.haxx.se/libcurl/c/CURLOPT_SSL_VERIFYHOST.html
         params[:ssl_verifypeer] = false
         params[:ssl_verifyhost] = 0
+        # TLSv1.0 and plus, allows to use a protocol potentially lower than the OS default
+        params[:sslversion] = :tlsv1
       end
 
       typhoeus_to_browser_opts.each do |typhoeus_opt, browser_opt|

--- a/spec/lib/browser_spec.rb
+++ b/spec/lib/browser_spec.rb
@@ -42,7 +42,8 @@ describe CMSScanner::Browser do
           cache_ttl: 200, connecttimeout: 10,
           userpwd: 'log:pwd', proxyuserpwd: 'u:pwd',
           cookiejar: options[:cookie_jar], cookiefile: options[:cookie_jar],
-          ssl_verifypeer: false, ssl_verifyhost: 0
+          ssl_verifypeer: false, ssl_verifyhost: 0,
+          sslversion: :tlsv1
         ).merge(headers: default[:headers].merge('Host' => 'testing', 'Test' => 'aa', 'Referer' => 'http://wp.lo/'))
       end
 


### PR DESCRIPTION
Fixes #108

Kali system defaults:
```console
# tail -n3 /etc/ssl/openssl.cnf 
[system_default_sect]
MinProtocol = TLSv1.2
CipherString = DEFAULT@SECLEVEL=2
```

Before the patch, nothing works:
```console
# wpscan --url https://tls-v1-0.badssl.com:1010/
_______________________________________________________________
        __          _______   _____
        \ \        / /  __ \ / ____|
         \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team
                       Version 3.6.3
          Sponsored by Sucuri - https://sucuri.net
      @_WPScan_, @ethicalhack3r, @erwan_lr, @_FireFart_
_______________________________________________________________


Scan Aborted: The url supplied 'https://tls-v1-0.badssl.com:1010/' seems to be down (SSL connect error)
root@kali:~# LD_LIBRARY_PATH=/root/tools/curl/lib/.libs wpscan --url https://tls-v1-0.badssl.com:1010/
_______________________________________________________________
        __          _______   _____
        \ \        / /  __ \ / ____|
         \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team
                       Version 3.6.3
          Sponsored by Sucuri - https://sucuri.net
      @_WPScan_, @ethicalhack3r, @erwan_lr, @_FireFart_
_______________________________________________________________


Scan Aborted: The url supplied 'https://tls-v1-0.badssl.com:1010/' seems to be down (SSL connect error)
root@kali:~# wpscan --url https://tls-v1-0.badssl.com:1010/ --disable-tls-checks
_______________________________________________________________
        __          _______   _____
        \ \        / /  __ \ / ____|
         \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team
                       Version 3.6.3
          Sponsored by Sucuri - https://sucuri.net
      @_WPScan_, @ethicalhack3r, @erwan_lr, @_FireFart_
_______________________________________________________________


Scan Aborted: The url supplied 'https://tls-v1-0.badssl.com:1010/' seems to be down (SSL connect error)
root@kali:~# LD_LIBRARY_PATH=/root/tools/curl/lib/.libs wpscan --url https://tls-v1-0.badssl.com:1010/ --disable-tls-checks
_______________________________________________________________
        __          _______   _____
        \ \        / /  __ \ / ____|
         \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team
                       Version 3.6.3
          Sponsored by Sucuri - https://sucuri.net
      @_WPScan_, @ethicalhack3r, @erwan_lr, @_FireFart_
_______________________________________________________________


Scan Aborted: The url supplied 'https://tls-v1-0.badssl.com:1010/' seems to be down (SSL connect error)
```

Then I apply the patch, notice that it still doesn't work using the current (pre-patch) libcurl, then it works with the updated libcurl:
```console
root@kali:~# wpscan --url https://tls-v1-0.badssl.com:1010/ --disable-tls-checks
_______________________________________________________________
        __          _______   _____
        \ \        / /  __ \ / ____|
         \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team
                       Version 3.6.3
          Sponsored by Sucuri - https://sucuri.net
      @_WPScan_, @ethicalhack3r, @erwan_lr, @_FireFart_
_______________________________________________________________


Scan Aborted: The url supplied 'https://tls-v1-0.badssl.com:1010/' seems to be down (SSL connect error)
root@kali:~# LD_LIBRARY_PATH=/root/tools/curl/lib/.libs wpscan --url https://tls-v1-0.badssl.com:1010/ --disable-tls-checks
_______________________________________________________________
        __          _______   _____
        \ \        / /  __ \ / ____|
         \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
          \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \
           \  /\  /  | |     ____) | (__| (_| | | | |
            \/  \/   |_|    |_____/ \___|\__,_|_| |_|

        WordPress Security Scanner by the WPScan Team
                       Version 3.6.3
          Sponsored by Sucuri - https://sucuri.net
      @_WPScan_, @ethicalhack3r, @erwan_lr, @_FireFart_
_______________________________________________________________


Scan Aborted: The remote website is up, but does not seem to be running WordPress.
root@kali:~# 
```