### PR TITLE
Add support for SAML authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 coverage
 pkg
 Gemfile.lock
+.DS_Store

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -58,6 +58,11 @@ module CMSScanner
         effective_url = target.homepage_res.effective_url # Basically get and follow location of target.url
         effective_uri = Addressable::URI.parse(effective_url)
 
+        if saml_authentication_required?(res)
+          # handle_saml_authentication(res)
+          raise Error::SAMLAuthenticationRequired
+        end
+
         # Case of http://a.com => https://a.com (or the opposite)
         if !NS::ParsedCli.ignore_main_redirect && target.uri.domain == effective_uri.domain &&
            target.uri.path == effective_uri.path && target.uri.scheme != effective_uri.scheme

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -94,10 +94,6 @@ module CMSScanner
         effective_url = target.homepage_res.effective_url # Basically get and follow location of target.url
         effective_uri = Addressable::URI.parse(effective_url)
 
-        if NS::ParsedCli.expect_saml && !saml_request?(effective_uri)
-          puts 'SAML authentication was expected but not required.'
-        end
-
         handle_saml_authentication(effective_uri) if saml_request?(effective_uri)
         handle_scheme_change(effective_url, effective_uri)
         return if target.in_scope?(effective_url)

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -71,6 +71,23 @@ module CMSScanner
         effective_uri.to_s.match?(/[?&]SAMLRequest/i)
       end
 
+      # Builds the command to run the authenticated scan
+      #
+      # @param [ String ] cookie_string
+      # @param [ String ] target_url
+      #
+      # @return [ String ] The command to run
+      def build_command(cookie_string, target_url)
+        # Filter out --expect-saml, --cookie-string, and --no-banner flags from the original options
+        filtered_options = ARGV.reject do |arg|
+          arg.start_with?('--expect-saml', '--cookie-string', '--no-banner')
+        end.join(' ')
+
+        # Build the command
+        "wpscan --url #{target_url} --cookie-string '#{cookie_string}' --no-banner #{filtered_options}"
+      end
+
+
       # Handle redirect if the target contains 'SAMLRequest', indicating a need for SAML authentication.
       #
       # @param [ Addressable::URI ] effective_uri
@@ -85,16 +102,10 @@ module CMSScanner
 
         # Authenticate using the ferrum browser
         cookie_string = BrowserAuthenticator.authenticate(effective_uri.to_s)
-
-        target_url = target.url # Needed for overriding in tests
-
-        # Filter out --expect-saml, --cookie-string, and --no-banner flags from the original options
-        filtered_options = ARGV.reject do |arg|
-          arg.start_with?('--expect-saml', '--cookie-string', '--no-banner')
-        end.join(' ')
+        target_url    = target.url # Needed for overriding in tests
+        command       = build_command(cookie_string, target_url)
 
         # Restart the scan with the cookies set and pass in the original options filtered
-        command = "wpscan --url #{target_url} --cookie-string '#{cookie_string}' --no-banner #{filtered_options}"
         raise Error::AuthenticatedRescanFailure, command unless Kernel.system(command)
 
         exit(NS::ExitCode::OK)

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -78,13 +78,26 @@ module CMSScanner
       #
       # @return [ Void ]
       def handle_saml_authentication(effective_uri)
+        # If we ended up here, the cookie_string is set, and no --expect-saml flag was included
+        raise Error::SAMLAuthenticationFailed if NS::ParsedCli.cookie_string && !NS::ParsedCli.expect_saml
+        # If we ended up here but no --expect-saml flag was included
         raise Error::SAMLAuthenticationRequired unless NS::ParsedCli.expect_saml
 
         # Authenticate using the ferrum browser
-        BrowserAuthenticator.authenticate(effective_uri.to_s)
+        cookie_string = BrowserAuthenticator.authenticate(effective_uri.to_s)
 
-        # Resume the scan by following the redirect
-        target.opts[:ignore_main_redirect] = true
+        target_url = target.url # Needed for overriding in tests
+
+        # Filter out --expect-saml, --cookie-string, and --no-banner flags from the original options
+        filtered_options = ARGV.reject do |arg|
+          arg.start_with?('--expect-saml', '--cookie-string', '--no-banner')
+        end.join(' ')
+
+        # Restart the scan with the cookies set and pass in the original options filtered
+        command = "wpscan --url #{target_url} --cookie-string '#{cookie_string}' --no-banner #{filtered_options}"
+        raise Error::AuthenticatedRescanFailure, command unless Kernel.system(command)
+
+        exit(NS::ExitCode::OK)
       end
 
       # Checks for redirects, an out of scope redirect will raise an Error::HTTPRedirect
@@ -93,6 +106,11 @@ module CMSScanner
       def handle_redirection(res)
         effective_url = target.homepage_res.effective_url # Basically get and follow location of target.url
         effective_uri = Addressable::URI.parse(effective_url)
+
+        if NS::ParsedCli.expect_saml && !saml_request?(effective_uri)
+          puts 'SAML authentication was expected but not required.'
+          puts # New line to serve as buffer before the scan results start
+        end
 
         handle_saml_authentication(effective_uri) if saml_request?(effective_uri)
         handle_scheme_change(effective_url, effective_uri)

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -51,6 +51,10 @@ module CMSScanner
         handle_redirection(res)
       end
 
+      # def saml_authentication_required(res)
+      #   return true
+      # end
+
       # Checks for redirects, an out of scope redirect will raise an Error::HTTPRedirect
       #
       # @param [ Typhoeus::Response ] res
@@ -58,10 +62,10 @@ module CMSScanner
         effective_url = target.homepage_res.effective_url # Basically get and follow location of target.url
         effective_uri = Addressable::URI.parse(effective_url)
 
-        if saml_authentication_required?(res)
-          # handle_saml_authentication(res)
-          raise Error::SAMLAuthenticationRequired
-        end
+        # if saml_authentication_required(res)
+        #   # handle_saml_authentication(res)
+        #   raise Error::SAMLAuthenticationRequired
+        # end
 
         # Case of http://a.com => https://a.com (or the opposite)
         if !NS::ParsedCli.ignore_main_redirect && target.uri.domain == effective_uri.domain &&

--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -51,7 +51,6 @@ module CMSScanner
                           exists: true,
                           advanced: true,
                           default: APP_DIR.join('user_agents.txt')),
-          OptCredentials.new(['--http-auth login:password']),
           OptPositiveInteger.new(['-t', '--max-threads VALUE', 'The max threads to use'],
                                  default: 5),
           OptPositiveInteger.new(['--throttle MilliSeconds', 'Milliseconds to wait before doing another web request. ' \
@@ -63,7 +62,7 @@ module CMSScanner
           OptBoolean.new(['--disable-tls-checks',
                           'Disables SSL/TLS certificate verification, and downgrade to TLS1.0+ ' \
                           '(requires cURL 7.66 for the latter)'])
-        ] + cli_browser_proxy_options + cli_browser_cookies_options + cli_browser_cache_options
+        ] + cli_authentication_options + cli_browser_cookies_options + cli_browser_cache_options
       end
 
       # @return [ Array<OptParseValidator::OptBase> ]
@@ -76,11 +75,13 @@ module CMSScanner
       end
 
       # @return [ Array<OptParseValidator::OptBase> ]
-      def cli_browser_proxy_options
+      def cli_authentication_options
         [
+          OptCredentials.new(['--http-auth login:password', 'HTTP Authentication credentials']),
           OptProxy.new(['--proxy protocol://IP:port',
                         'Supported protocols depend on the cURL installed']),
-          OptCredentials.new(['--proxy-auth login:password'])
+          OptCredentials.new(['--proxy-auth login:password', 'Proxy authentication credentials']),
+          OptBoolean.new(['--expect-saml', 'Expect SAML authentication to be required'], advanced: true)
         ]
       end
 

--- a/cms_scanner.gemspec
+++ b/cms_scanner.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'typhoeus', '>= 1.3', '< 1.5'
   s.add_dependency 'xmlrpc', '~> 0.3'
   s.add_dependency 'yajl-ruby', '~> 1.4.1' # Better JSON parser regarding memory usage
-
   s.add_dependency 'sys-proctable', '>= 1.2.2', '< 1.4.0' # Required by get_process_mem for Windows OS.
+  s.add_dependency "ferrum", "~> 0.8"
 
   s.add_development_dependency 'bundler',             '>= 1.6'
   s.add_development_dependency 'rake',                '~> 13.0'

--- a/lib/cms_scanner.rb
+++ b/lib/cms_scanner.rb
@@ -41,6 +41,7 @@ require 'cms_scanner/references'
 require 'cms_scanner/finders'
 require 'cms_scanner/vulnerability'
 require 'cms_scanner/progressbar_null_output'
+require 'cms_scanner/browser_authenticator'
 
 # Module
 module CMSScanner

--- a/lib/cms_scanner/browser_authenticator.rb
+++ b/lib/cms_scanner/browser_authenticator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'ferrum'
+
+module BrowserAuthenticator
+  def self.authenticate(login_url)
+    browser = Ferrum::Browser.new(headless: false)
+
+    browser.goto(login_url)
+
+    # Here you might prompt the user to manually complete the login
+    puts 'Please log in through the opened browser window. Press enter once done.'
+    gets # Waits for user input
+
+    cookies = browser.cookies.all.to_a
+    browser.quit
+
+    cookies
+  end
+end

--- a/lib/cms_scanner/browser_authenticator.rb
+++ b/lib/cms_scanner/browser_authenticator.rb
@@ -12,9 +12,6 @@ module BrowserAuthenticator
     puts 'Please log in through the opened browser window. Press enter once done.'
     gets # Waits for user input
 
-    cookies = browser.cookies.all.to_a
     browser.quit
-
-    cookies
   end
 end

--- a/lib/cms_scanner/errors.rb
+++ b/lib/cms_scanner/errors.rb
@@ -9,3 +9,4 @@ end
 
 require_relative 'errors/http'
 require_relative 'errors/scan'
+require_relative 'errors/saml'

--- a/lib/cms_scanner/errors/http.rb
+++ b/lib/cms_scanner/errors/http.rb
@@ -63,7 +63,7 @@ module CMSScanner
       end
 
       def to_s
-        "The URL supplied redirects to #{redirect_uri}. Use the --ignore-main-redirect "\
+        "The URL blah blah blah supplied redirects to #{redirect_uri}. Use the --ignore-main-redirect "\
           'option to ignore the redirection and scan the target, or change the --url option ' \
           'value to the redirected URL.'
       end

--- a/lib/cms_scanner/errors/http.rb
+++ b/lib/cms_scanner/errors/http.rb
@@ -63,7 +63,7 @@ module CMSScanner
       end
 
       def to_s
-        "The URL blah blah blah supplied redirects to #{redirect_uri}. Use the --ignore-main-redirect "\
+        "The URL supplied redirects to #{redirect_uri}. Use the --ignore-main-redirect "\
           'option to ignore the redirection and scan the target, or change the --url option ' \
           'value to the redirected URL.'
       end

--- a/lib/cms_scanner/errors/saml.rb
+++ b/lib/cms_scanner/errors/saml.rb
@@ -6,8 +6,42 @@ module CMSScanner
     class SAMLAuthenticationRequired < Standard
       # :nocov:
       def to_s
+        'SAML authentication is required to access this resource, consider using --expect-saml.'
+      end
+      # :nocov:
+    end
+
+    # SAML Authentication Failed Error
+    class SAMLAuthenticationFailed < Standard
+      # :nocov:
+      def to_s
         'SAML authentication is required to access this resource. ' \
-          'Please ensure SAML authentication credentials are provided.'
+          'Please ensure correct authentication credentials.'
+      end
+      # :nocov:
+    end
+
+    # SAML Authentication Failed Error
+    class AuthenticatedRescanFailure < Standard
+      attr_reader :command
+
+      # @param [ String ] url
+      def initialize(wpscan_command)
+        @command = wpscan_command
+      end
+
+      # :nocov:
+      def to_s
+        "Following authentication, the system failed to execute follow-up command: #{command}"
+      end
+      # :nocov:
+    end
+
+    # Ferrum Browser Error
+    class BrowserFailed < Standard
+      # :nocov:
+      def to_s
+        'The browser was closed or failed before authentication could be completed.'
       end
       # :nocov:
     end

--- a/lib/cms_scanner/errors/saml.rb
+++ b/lib/cms_scanner/errors/saml.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module CMSScanner
+	module Error
+		# SAML Authentication Required Error
+		class SAMLAuthenticationRequired < Standard
+			def to_s
+			  "SAML authentication is required to access this resource. Please ensure SAML authentication credentials are provided."
+			end
+		  end
+	end
+end

--- a/lib/cms_scanner/errors/saml.rb
+++ b/lib/cms_scanner/errors/saml.rb
@@ -4,10 +4,12 @@ module CMSScanner
   module Error
     # SAML Authentication Required Error
     class SAMLAuthenticationRequired < Standard
+      # :nocov:
       def to_s
-        'SAML authentication is required to access this resource.'\
+        'SAML authentication is required to access this resource. ' \
           'Please ensure SAML authentication credentials are provided.'
       end
+      # :nocov:
     end
   end
 end

--- a/lib/cms_scanner/errors/saml.rb
+++ b/lib/cms_scanner/errors/saml.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 module CMSScanner
-	module Error
-		# SAML Authentication Required Error
-		class SAMLAuthenticationRequired < Standard
-			def to_s
-			  "SAML authentication is required to access this resource. Please ensure SAML authentication credentials are provided."
-			end
-		  end
-	end
+  module Error
+    # SAML Authentication Required Error
+    class SAMLAuthenticationRequired < Standard
+      def to_s
+        'SAML authentication is required to access this resource.'\
+          'Please ensure SAML authentication credentials are provided.'
+      end
+    end
+  end
 end

--- a/lib/cms_scanner/version.rb
+++ b/lib/cms_scanner/version.rb
@@ -2,5 +2,5 @@
 
 # Version
 module CMSScanner
-  VERSION = '0.13.9'
+  VERSION = '0.14.9'
 end

--- a/lib/cms_scanner/version.rb
+++ b/lib/cms_scanner/version.rb
@@ -2,5 +2,5 @@
 
 # Version
 module CMSScanner
-  VERSION = '0.14.9'
+  VERSION = '0.14.0'
 end

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -152,7 +152,7 @@ describe CMSScanner::Controller::Core do
             it 'raises an error' do
               expect { core.before_scan }.to raise_error(
                 CMSScanner::Error::HTTPRedirect,
-                "The URL supplied redirects to #{redirection}." \
+                "The URL blah blah blah supplied redirects to #{redirection}." \
                 ' Use the --ignore-main-redirect option to ignore the redirection and scan the target,' \
                 ' or change the --url option value to the redirected URL.'
               )

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -19,7 +19,7 @@ describe CMSScanner::Controller::Core do
           banner cache_dir cache_ttl clear_cache connect_timeout cookie_jar cookie_string
           detection_mode disable_tls_checks force format headers help hh http_auth ignore_main_redirect
           max_scan_duration max_threads output proxy proxy_auth random_user_agent request_timeout
-          scope throttle url user_agent user_agents_list verbose version vhost
+          scope throttle url user_agent user_agents_list verbose version vhost expect_saml
         ]
       )
     end


### PR DESCRIPTION
This PR will serve as the base for several other PR's. As they get reviewed and approved, I will merge them into this one once the feature is a functioning MVP.

- [x] Update gem to identify the SAML redirect
- [x] Update gem to add SAML flag to follow the redirect and open the browser (or submit via headless browser)
- [x] Update gem to accept and handle session and cookies
- [x] Clean up and complete authentication and scan

---
**Testing Instructions**

These specific instructions are dependent on being able to build and run the WPScan CLI Scanner locally (rather than through docker).
See: https://github.com/wpscanteam/wpscan

Update `wpscan/Gemfile` to add:
`gem 'cms_scanner', path: '/absolute-path-to-the-scanner/CMSScanner'`

You **_may_** also need to comment the following line from the `wpscan.gemspec`:
`s.add_dependency 'cms_scanner', '~> 0.13.9'`

- Run the scanner using the new `--expect-saml` flag
- To test against a server with SAML authentication you can use `http://3.135.88.75/`
