### PR TITLE
Add SAML flag to follow the redirect and open the browser

### DIFF
--- a/app/controllers/core/cli_options.rb
+++ b/app/controllers/core/cli_options.rb
@@ -51,7 +51,6 @@ module CMSScanner
                           exists: true,
                           advanced: true,
                           default: APP_DIR.join('user_agents.txt')),
-          OptCredentials.new(['--http-auth login:password']),
           OptPositiveInteger.new(['-t', '--max-threads VALUE', 'The max threads to use'],
                                  default: 5),
           OptPositiveInteger.new(['--throttle MilliSeconds', 'Milliseconds to wait before doing another web request. ' \
@@ -63,7 +62,7 @@ module CMSScanner
           OptBoolean.new(['--disable-tls-checks',
                           'Disables SSL/TLS certificate verification, and downgrade to TLS1.0+ ' \
                           '(requires cURL 7.66 for the latter)'])
-        ] + cli_browser_proxy_options + cli_browser_cookies_options + cli_browser_cache_options
+        ] + cli_authentication_options + cli_browser_cookies_options + cli_browser_cache_options
       end
 
       # @return [ Array<OptParseValidator::OptBase> ]
@@ -76,11 +75,13 @@ module CMSScanner
       end
 
       # @return [ Array<OptParseValidator::OptBase> ]
-      def cli_browser_proxy_options
+      def cli_authentication_options
         [
+          OptCredentials.new(['--http-auth login:password', 'HTTP Authentication credentials']),
           OptProxy.new(['--proxy protocol://IP:port',
                         'Supported protocols depend on the cURL installed']),
-          OptCredentials.new(['--proxy-auth login:password'])
+          OptCredentials.new(['--proxy-auth login:password', 'Proxy authentication credentials']),
+          OptBoolean.new(['--expect-saml', 'Expect SAML authentication to be required'], advanced: true)
         ]
       end
 

--- a/cms_scanner.gemspec
+++ b/cms_scanner.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'typhoeus', '>= 1.3', '< 1.5'
   s.add_dependency 'xmlrpc', '~> 0.3'
   s.add_dependency 'yajl-ruby', '~> 1.4.1' # Better JSON parser regarding memory usage
-
   s.add_dependency 'sys-proctable', '>= 1.2.2', '< 1.4.0' # Required by get_process_mem for Windows OS.
+  s.add_dependency "ferrum", "~> 0.8"
 
   s.add_development_dependency 'bundler',             '>= 1.6'
   s.add_development_dependency 'rake',                '~> 13.0'

--- a/lib/cms_scanner.rb
+++ b/lib/cms_scanner.rb
@@ -41,6 +41,7 @@ require 'cms_scanner/references'
 require 'cms_scanner/finders'
 require 'cms_scanner/vulnerability'
 require 'cms_scanner/progressbar_null_output'
+require 'cms_scanner/browser_authenticator'
 
 # Module
 module CMSScanner

--- a/lib/cms_scanner/browser_authenticator.rb
+++ b/lib/cms_scanner/browser_authenticator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'ferrum'
+
+module BrowserAuthenticator
+  def self.authenticate(login_url)
+    browser = Ferrum::Browser.new(headless: false)
+
+    browser.goto(login_url)
+
+    # Here you might prompt the user to manually complete the login
+    puts 'Please log in through the opened browser window. Press enter once done.'
+    gets # Waits for user input
+
+    cookies = browser.cookies.all.to_a
+    browser.quit
+
+    cookies
+  end
+end

--- a/spec/app/controllers/core_spec.rb
+++ b/spec/app/controllers/core_spec.rb
@@ -19,7 +19,7 @@ describe CMSScanner::Controller::Core do
           banner cache_dir cache_ttl clear_cache connect_timeout cookie_jar cookie_string
           detection_mode disable_tls_checks force format headers help hh http_auth ignore_main_redirect
           max_scan_duration max_threads output proxy proxy_auth random_user_agent request_timeout
-          scope throttle url user_agent user_agents_list verbose version vhost
+          scope throttle url user_agent user_agents_list verbose version vhost expect_saml
         ]
       )
     end


### PR DESCRIPTION
This is designed to be one step toward completing the MVP feature here: https://github.com/wpscanteam/CMSScanner/pull/253

Changes:
- Adds the flag to expect SAML
- Adds a new dependency that will allow us to interact with a regular browser (and also supports headless browser as well)
- Collects the cookies that we will be able to use in the next task

Testing instructions can be found in the above PR as well.