### PR TITLE
Add authenticating onto client site

### DIFF
--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -94,10 +94,6 @@ module CMSScanner
         effective_url = target.homepage_res.effective_url # Basically get and follow location of target.url
         effective_uri = Addressable::URI.parse(effective_url)
 
-        if NS::ParsedCli.expect_saml && !saml_request?(effective_uri)
-          puts 'SAML authentication was expected but not required.'
-        end
-
         handle_saml_authentication(effective_uri) if saml_request?(effective_uri)
         handle_scheme_change(effective_url, effective_uri)
         return if target.in_scope?(effective_url)

--- a/app/controllers/core.rb
+++ b/app/controllers/core.rb
@@ -78,13 +78,26 @@ module CMSScanner
       #
       # @return [ Void ]
       def handle_saml_authentication(effective_uri)
+        # If we ended up here, the cookie_string is set, and no --expect-saml flag was included
+        raise Error::SAMLAuthenticationFailed if NS::ParsedCli.cookie_string && !NS::ParsedCli.expect_saml
+        # If we ended up here but no --expect-saml flag was included
         raise Error::SAMLAuthenticationRequired unless NS::ParsedCli.expect_saml
 
         # Authenticate using the ferrum browser
-        BrowserAuthenticator.authenticate(effective_uri.to_s)
+        cookie_string = BrowserAuthenticator.authenticate(effective_uri.to_s)
 
-        # Resume the scan by following the redirect
-        target.opts[:ignore_main_redirect] = true
+        target_url = target.url # Needed for overriding in tests
+
+        # Filter out --expect-saml, --cookie-string, and --no-banner flags from the original options
+        filtered_options = ARGV.reject do |arg|
+          arg.start_with?('--expect-saml', '--cookie-string', '--no-banner')
+        end.join(' ')
+
+        # Restart the scan with the cookies set and pass in the original options filtered
+        command = "wpscan --url #{target_url} --cookie-string '#{cookie_string}' --no-banner #{filtered_options}"
+        raise Error::AuthenticatedRescanFailure, command unless Kernel.system(command)
+
+        exit(NS::ExitCode::OK)
       end
 
       # Checks for redirects, an out of scope redirect will raise an Error::HTTPRedirect
@@ -93,6 +106,11 @@ module CMSScanner
       def handle_redirection(res)
         effective_url = target.homepage_res.effective_url # Basically get and follow location of target.url
         effective_uri = Addressable::URI.parse(effective_url)
+
+        if NS::ParsedCli.expect_saml && !saml_request?(effective_uri)
+          puts 'SAML authentication was expected but not required.'
+          puts # New line to serve as buffer before the scan results start
+        end
 
         handle_saml_authentication(effective_uri) if saml_request?(effective_uri)
         handle_scheme_change(effective_url, effective_uri)

--- a/lib/cms_scanner/browser_authenticator.rb
+++ b/lib/cms_scanner/browser_authenticator.rb
@@ -12,9 +12,6 @@ module BrowserAuthenticator
     puts 'Please log in through the opened browser window. Press enter once done.'
     gets # Waits for user input
 
-    cookies = browser.cookies.all.to_a
     browser.quit
-
-    cookies
   end
 end

--- a/lib/cms_scanner/errors/saml.rb
+++ b/lib/cms_scanner/errors/saml.rb
@@ -6,8 +6,42 @@ module CMSScanner
     class SAMLAuthenticationRequired < Standard
       # :nocov:
       def to_s
+        'SAML authentication is required to access this resource, consider using --expect-saml.'
+      end
+      # :nocov:
+    end
+
+    # SAML Authentication Failed Error
+    class SAMLAuthenticationFailed < Standard
+      # :nocov:
+      def to_s
         'SAML authentication is required to access this resource. ' \
-          'Please ensure SAML authentication credentials are provided.'
+          'Please ensure correct authentication credentials.'
+      end
+      # :nocov:
+    end
+
+    # SAML Authentication Failed Error
+    class AuthenticatedRescanFailure < Standard
+      attr_reader :command
+
+      # @param [ String ] url
+      def initialize(wpscan_command)
+        @command = wpscan_command
+      end
+
+      # :nocov:
+      def to_s
+        "Following authentication, the system failed to execute follow-up command: #{command}"
+      end
+      # :nocov:
+    end
+
+    # Ferrum Browser Error
+    class BrowserFailed < Standard
+      # :nocov:
+      def to_s
+        'The browser was closed or failed before authentication could be completed.'
       end
       # :nocov:
     end


### PR DESCRIPTION
This is designed to be one step toward completing the MVP feature here: https://github.com/wpscanteam/CMSScanner/pull/253

Changes:
- Uses the authenticated cookies in a subsequent scan
- Adds unit tests and error handling

Testing instructions can be found in the above PR as well.

*Additional testing*
- Try causing an uncaught exception.
   - Manually close the popup browser window before continuing
   - Don't authenticate but press enter in the terminal to continue