### PR TITLE
Default format to 'cli-no-colour' when output to file

### DIFF
--- a/lib/cms_scanner/controllers.rb
+++ b/lib/cms_scanner/controllers.rb
@@ -40,6 +40,7 @@ module CMSScanner
       NS::ParsedCli.options     = option_parser.results
       first.class.option_parser = option_parser # To be able to output the help when -h/--hh
 
+      NS::ParsedCli.options[:format] ||= 'cli-no-colour' if NS::ParsedCli.output
       redirect_output_to_file(NS::ParsedCli.output) if NS::ParsedCli.output
 
       Timeout.timeout(NS::ParsedCli.max_scan_duration, NS::Error::MaxScanDurationReached) do


### PR DESCRIPTION
When use the flag `--output FILE`, CMSScanner also write escape sequences to `FILE`.
```rb
1   _______________________________________________________________
  1          __          _______   _____
  2          \ \        / /  __ \ / ____|
  3           \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
  4            \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \
  5             \  /\  /  | |     ____) | (__| (_| | | | |
  6              \/  \/   |_|    |_____/ \___|\__,_|_| |_|
  7 
  8          WordPress Security Scanner by the WPScan Team
  9                          Version 3.8.25
 10        Sponsored by Automattic - https://automattic.com/
 11        @_WPScan_, @ethicalhack3r, @erwan_lr, @firefart
 12 _______________________________________________________________
 13 
 14 ^[[32m[+]^[[0m URL: http://localhost/ [::1]
 15 ^[[32m[+]^[[0m Started: Tue Jul  2 16:33:45 2024
 16 
 17 Interesting Finding(s):
 18 
 19 ^[[32m[+]^[[0m Headers
 20  | Interesting Entry: Server: Apache
 21  | Found By: Headers (Passive Detection)
 22  | Confidence: 100%
```
This PR solve this issue.
```rb
1   _______________________________________________________________
  1          __          _______   _____
  2          \ \        / /  __ \ / ____|
  3           \ \  /\  / /| |__) | (___   ___  __ _ _ __ ®
  4            \ \/  \/ / |  ___/ \___ \ / __|/ _` | '_ \
  5             \  /\  /  | |     ____) | (__| (_| | | | |
  6              \/  \/   |_|    |_____/ \___|\__,_|_| |_|
  7 
  8          WordPress Security Scanner by the WPScan Team
  9                          Version 3.8.25
 10        Sponsored by Automattic - https://automattic.com/
 11        @_WPScan_, @ethicalhack3r, @erwan_lr, @firefart
 12 _______________________________________________________________
 13 
 14 [+] URL: http://localhost/ [::1]
 15 [+] Started: Tue Jul  2 16:53:59 2024
 16 
 17 Interesting Finding(s):
 18 
 19 [+] Headers
 20  | Interesting Entry: Server: Apache
 21  | Found By: Headers (Passive Detection)
 22  | Confidence: 100%
```